### PR TITLE
Add the test-suite bash file which runs once for the whole test suite.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ jobs:
           id: setup-bats
           uses: bats-core/bats-action@3.0.0
 
-        - name: Build the docker image
-          run: docker build -t pollen-rss .
-
         - name: Prepare reports directory
           run: mkdir -p reports
 

--- a/test/scenarios/setup_suite.bash
+++ b/test/scenarios/setup_suite.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+setup_suite() {
+    rm -rf logs
+    echo "# Building the Docker image..." >&3
+    docker build -t pollen-rss .
+}


### PR DESCRIPTION
Since this builds the docker image, we don't need to build the docker image in the github workflow.